### PR TITLE
refactor: paging returns either offset or count

### DIFF
--- a/api/v1/http/docs/docs.go
+++ b/api/v1/http/docs/docs.go
@@ -432,8 +432,8 @@ const docTemplate = `{
                         "$ref": "#/definitions/v1.Embedding"
                     }
                 },
-                "n": {
-                    "type": "integer"
+                "page": {
+                    "$ref": "#/definitions/v1.Page"
                 }
             }
         },
@@ -441,6 +441,19 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.Page": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "Count is number of all\nresults if provided.",
+                    "type": "integer"
+                },
+                "next": {
+                    "description": "Next is either a number\nor a string ID which allows\nresuming paging if provided.",
                     "type": "string"
                 }
             }
@@ -468,8 +481,8 @@ const docTemplate = `{
                         }
                     }
                 },
-                "n": {
-                    "type": "integer"
+                "page": {
+                    "$ref": "#/definitions/v1.Page"
                 }
             }
         },
@@ -494,8 +507,8 @@ const docTemplate = `{
         "v1.ProvidersResponse": {
             "type": "object",
             "properties": {
-                "n": {
-                    "type": "integer"
+                "page": {
+                    "$ref": "#/definitions/v1.Page"
                 },
                 "providers": {
                     "type": "array",

--- a/api/v1/http/docs/swagger.json
+++ b/api/v1/http/docs/swagger.json
@@ -425,8 +425,8 @@
                         "$ref": "#/definitions/v1.Embedding"
                     }
                 },
-                "n": {
-                    "type": "integer"
+                "page": {
+                    "$ref": "#/definitions/v1.Page"
                 }
             }
         },
@@ -434,6 +434,19 @@
             "type": "object",
             "properties": {
                 "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.Page": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "Count is number of all\nresults if provided.",
+                    "type": "integer"
+                },
+                "next": {
+                    "description": "Next is either a number\nor a string ID which allows\nresuming paging if provided.",
                     "type": "string"
                 }
             }
@@ -461,8 +474,8 @@
                         }
                     }
                 },
-                "n": {
-                    "type": "integer"
+                "page": {
+                    "$ref": "#/definitions/v1.Page"
                 }
             }
         },
@@ -487,8 +500,8 @@
         "v1.ProvidersResponse": {
             "type": "object",
             "properties": {
-                "n": {
-                    "type": "integer"
+                "page": {
+                    "$ref": "#/definitions/v1.Page"
                 },
                 "providers": {
                     "type": "array",

--- a/api/v1/http/docs/swagger.yaml
+++ b/api/v1/http/docs/swagger.yaml
@@ -43,12 +43,26 @@ definitions:
         items:
           $ref: '#/definitions/v1.Embedding'
         type: array
-      "n":
-        type: integer
+      page:
+        $ref: '#/definitions/v1.Page'
     type: object
   v1.ErrorResponse:
     properties:
       error:
+        type: string
+    type: object
+  v1.Page:
+    properties:
+      count:
+        description: |-
+          Count is number of all
+          results if provided.
+        type: integer
+      next:
+        description: |-
+          Next is either a number
+          or a string ID which allows
+          resuming paging if provided.
         type: string
     type: object
   v1.Projection:
@@ -67,8 +81,8 @@ definitions:
             $ref: '#/definitions/v1.Embedding'
           type: array
         type: object
-      "n":
-        type: integer
+      page:
+        $ref: '#/definitions/v1.Page'
     type: object
   v1.Provider:
     properties:
@@ -85,8 +99,8 @@ definitions:
     type: object
   v1.ProvidersResponse:
     properties:
-      "n":
-        type: integer
+      page:
+        $ref: '#/definitions/v1.Page'
       providers:
         items:
           $ref: '#/definitions/v1.Provider'

--- a/api/v1/http/providers.go
+++ b/api/v1/http/providers.go
@@ -56,7 +56,7 @@ func (s *Server) GetAllProviders(c *fiber.Ctx) error {
 		filter.Limit = limit
 	}
 
-	providers, n, err := s.ProvidersService.GetProviders(context.TODO(), filter)
+	providers, page, err := s.ProvidersService.GetProviders(context.TODO(), filter)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(v1.ErrorResponse{
 			Error: err.Error(),
@@ -65,7 +65,7 @@ func (s *Server) GetAllProviders(c *fiber.Ctx) error {
 
 	return c.JSON(v1.ProvidersResponse{
 		Providers: providers,
-		N:         n,
+		Page:      page,
 	})
 }
 
@@ -140,7 +140,7 @@ func (s *Server) GetProviderEmbeddings(c *fiber.Ctx) error {
 		filter.Limit = limit
 	}
 
-	embeddings, n, err := s.ProvidersService.GetProviderEmbeddings(context.TODO(), uid.String(), filter)
+	embeddings, page, err := s.ProvidersService.GetProviderEmbeddings(context.TODO(), uid.String(), filter)
 	if err != nil {
 		if code := v1.ErrorCode(err); code == v1.ENOTFOUND {
 			return c.Status(fiber.StatusNotFound).JSON(v1.ErrorResponse{
@@ -155,7 +155,7 @@ func (s *Server) GetProviderEmbeddings(c *fiber.Ctx) error {
 
 	return c.JSON(v1.EmbeddingsResponse{
 		Embeddings: embeddings,
-		N:          n,
+		Page:       page,
 	})
 }
 
@@ -204,7 +204,7 @@ func (s *Server) GetProviderProjections(c *fiber.Ctx) error {
 		}
 	}
 
-	projections, n, err := s.ProvidersService.GetProviderProjections(context.TODO(), uid.String(), filter)
+	projections, page, err := s.ProvidersService.GetProviderProjections(context.TODO(), uid.String(), filter)
 	if err != nil {
 		if code := v1.ErrorCode(err); code == v1.ENOTFOUND {
 			return c.Status(fiber.StatusNotFound).JSON(v1.ErrorResponse{
@@ -219,7 +219,7 @@ func (s *Server) GetProviderProjections(c *fiber.Ctx) error {
 
 	return c.JSON(v1.ProjectionsResponse{
 		Projections: projections,
-		N:           n,
+		Page:        page,
 	})
 }
 

--- a/api/v1/http/providers_test.go
+++ b/api/v1/http/providers_test.go
@@ -44,8 +44,8 @@ func TestGetAllProviders(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if ret.N != count {
-			t.Errorf("expected providers: %d, got: %d", count, ret.N)
+		if *ret.Page.Count != count {
+			t.Errorf("expected providers: %d, got: %d", count, *ret.Page.Count)
 		}
 	})
 
@@ -83,8 +83,8 @@ func TestGetAllProviders(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if ret.N != count {
-			t.Errorf("expected total providers: %d, got: %d", count, ret.N)
+		if *ret.Page.Count != count {
+			t.Errorf("expected total providers: %d, got: %d", count, *ret.Page.Count)
 		}
 
 		if n := len(ret.Providers); n != limit {
@@ -260,8 +260,8 @@ func TestGetProviderEmbeddings(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if ret.N != count {
-			t.Errorf("expected providers: %d, got: %d", count, ret.N)
+		if *ret.Page.Count != count {
+			t.Errorf("expected providers: %d, got: %d", count, *ret.Page.Count)
 		}
 	})
 
@@ -370,8 +370,8 @@ func TestGetProviderProjections(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if ret.N != count {
-			t.Errorf("expected providers: %d, got: %d", count, ret.N)
+		if *ret.Page.Count != count {
+			t.Errorf("expected providers: %d, got: %d", count, *ret.Page.Count)
 		}
 
 		// we should get both 2D and 2D projections back
@@ -417,8 +417,8 @@ func TestGetProviderProjections(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if ret.N != count {
-			t.Errorf("expected providers: %d, got: %d", count, ret.N)
+		if *ret.Page.Count != count {
+			t.Errorf("expected providers: %d, got: %d", count, *ret.Page.Count)
 		}
 
 		// we should only get 2D projections
@@ -545,8 +545,8 @@ func TestDropProviderEmbeddings(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if embRet.N != 0 {
-			t.Errorf("expected providers: %d, got: %d", 0, embRet.N)
+		if *embRet.Page.Count != 0 {
+			t.Errorf("expected providers: %d, got: %d", 0, *embRet.Page.Count)
 		}
 
 		// Verify no projections are returned for this provider
@@ -573,8 +573,8 @@ func TestDropProviderEmbeddings(t *testing.T) {
 			t.Fatalf("failed to decode body: %v", err)
 		}
 
-		if projRet.N != 0 {
-			t.Errorf("expected providers: %d, got: %d", 0, projRet.N)
+		if *projRet.Page.Count != 0 {
+			t.Errorf("expected providers: %d, got: %d", 0, *projRet.Page.Count)
 		}
 	})
 

--- a/api/v1/memory/providers_test.go
+++ b/api/v1/memory/providers_test.go
@@ -87,13 +87,13 @@ func TestGetProviders(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			px, n, err := ps.GetProviders(context.TODO(), tc.filter)
+			px, page, err := ps.GetProviders(context.TODO(), tc.filter)
 			if !tc.expErr && err != nil {
 				t.Fatal(err)
 			}
 
-			if n != tc.expMatches {
-				t.Errorf("expected providers: %d, got: %d", tc.expMatches, n)
+			if *page.Count != tc.expMatches {
+				t.Errorf("expected providers: %d, got: %d", tc.expMatches, *page.Count)
 			}
 
 			if tc.expRes != len(px) {
@@ -200,13 +200,13 @@ func TestGetProviderEmbeddings(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			px, n, err := ps.GetProviderEmbeddings(context.TODO(), p.UID, tc.filter)
+			px, page, err := ps.GetProviderEmbeddings(context.TODO(), p.UID, tc.filter)
 			if !tc.expErr && err != nil {
 				t.Fatal(err)
 			}
 
-			if n != tc.expMatches {
-				t.Errorf("expected embeddings: %d, got: %d", tc.expMatches, n)
+			if *page.Count != tc.expMatches {
+				t.Errorf("expected embeddings: %d, got: %d", tc.expMatches, *page.Count)
 			}
 
 			if tc.expRes != len(px) {
@@ -285,13 +285,13 @@ func TestGetProviderProjections(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			px, n, err := ps.GetProviderProjections(context.TODO(), p.UID, tc.filter)
+			px, page, err := ps.GetProviderProjections(context.TODO(), p.UID, tc.filter)
 			if !tc.expErr && err != nil {
 				t.Fatal(err)
 			}
 
-			if n != tc.expMatches {
-				t.Errorf("expected projections: %d, got: %d", tc.expMatches, n)
+			if *page.Count != tc.expMatches {
+				t.Errorf("expected projections: %d, got: %d", tc.expMatches, *page.Count)
 			}
 
 			// NOTE: we seed the data so we expect the filter seeds to be retrurned
@@ -386,7 +386,7 @@ func TestDropProviderEmbeddings(t *testing.T) {
 			t.Fatalf("expected error: %s", err)
 		}
 
-		px, n, err := ps.GetProviderProjections(context.TODO(), p.UID, v1.ProviderFilter{})
+		px, page, err := ps.GetProviderProjections(context.TODO(), p.UID, v1.ProviderFilter{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -399,11 +399,11 @@ func TestDropProviderEmbeddings(t *testing.T) {
 			t.Fatalf("expected no projections, got: %d", dim3D)
 		}
 
-		if n != 0 {
-			t.Fatalf("expected no projections, got: %d", n)
+		if *page.Count != 0 {
+			t.Fatalf("expected no projections, got: %d", page)
 		}
 
-		ex, n, err := ps.GetProviderEmbeddings(context.TODO(), p.UID, v1.ProviderFilter{})
+		ex, page, err := ps.GetProviderEmbeddings(context.TODO(), p.UID, v1.ProviderFilter{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -412,8 +412,8 @@ func TestDropProviderEmbeddings(t *testing.T) {
 			t.Fatalf("expected no projections, got: %d", len(ex))
 		}
 
-		if n != 0 {
-			t.Fatalf("expected no projections, got: %d", n)
+		if *page.Count != 0 {
+			t.Fatalf("expected no projections, got: %d", page)
 		}
 	})
 

--- a/api/v1/providers.go
+++ b/api/v1/providers.go
@@ -49,7 +49,7 @@ type ProviderFilter struct {
 	// Filtering fields.
 	Dim *Dim `json:"dim"`
 	// Restrict to subset of range.
-	Offset int `json:"offset"`
+	Offset any `json:"offset"`
 	Limit  int `json:"limit"`
 }
 
@@ -72,13 +72,13 @@ type ProvidersService interface {
 	// AddProvider creates a new provider and returns it.
 	AddProvider(ctx context.Context, name string, metadata map[string]any) (*Provider, error)
 	// GetProviders returns a list of providers filtered by filter.
-	GetProviders(ctx context.Context, filter ProviderFilter) ([]*Provider, int, error)
+	GetProviders(ctx context.Context, filter ProviderFilter) ([]*Provider, Page, error)
 	// GetProviderByUID returns the provider with the given uuid.
 	GetProviderByUID(ctx context.Context, uid string) (*Provider, error)
 	// GetProviderEmbeddings returns embeddings for the provider with the given uid.
-	GetProviderEmbeddings(ctx context.Context, uid string, filter ProviderFilter) ([]Embedding, int, error)
+	GetProviderEmbeddings(ctx context.Context, uid string, filter ProviderFilter) ([]Embedding, Page, error)
 	// GetProviderProjections returns embeddings projections for the provider with the given uid.
-	GetProviderProjections(ctx context.Context, uid string, filter ProviderFilter) (map[Dim][]Embedding, int, error)
+	GetProviderProjections(ctx context.Context, uid string, filter ProviderFilter) (map[Dim][]Embedding, Page, error)
 	// UpdateProviderEmbeddings generates embeddings for the provider with the given uid.
 	UpdateProviderEmbeddings(ctx context.Context, uid string, update Embedding, projection Projection) (*Embedding, error)
 	// DropProviderEmbeddings drops all provider embeddings from the store

--- a/api/v1/response.go
+++ b/api/v1/response.go
@@ -5,22 +5,36 @@ const (
 	DefaultLimit = 20
 )
 
+// Page is used for API paging.
+// Some upstream providers do not
+// provide full count, but instead
+// the ID of the next Page.
+type Page struct {
+	// Next is either a number
+	// or a string ID which allows
+	// resuming paging if provided.
+	Next *string `json:"next,omitempty"`
+	// Count is number of all
+	// results if provided.
+	Count *int `json:"count,omitempty"`
+}
+
 // ProvidersResponse is returned when querying providers.
 type ProvidersResponse struct {
 	Providers []*Provider `json:"providers"`
-	N         int         `json:"n"`
+	Page      Page        `json:"page"`
 }
 
 // ProjectionsResponse is returned when querying provider embeddings projections
 type ProjectionsResponse struct {
 	Projections map[Dim][]Embedding `json:"embeddings"`
-	N           int                 `json:"n"`
+	Page        Page                `json:"page"`
 }
 
 // EmbeddingsResponse is returned when querying provider embeddings.
 type EmbeddingsResponse struct {
 	Embeddings []Embedding `json:"embeddings"`
-	N          int         `json:"n"`
+	Page       Page        `json:"page"`
 }
 
 // ErrorResponse represents a JSON structure for error output.


### PR DESCRIPTION
This is due to some upstream vector store providers returning vector offsets when scrolling the list of stored vectors.