### PR TITLE
fix: return empty projections if none is stored when recomputing

### DIFF
--- a/api/v1/internal/projection/projection.go
+++ b/api/v1/internal/projection/projection.go
@@ -111,6 +111,12 @@ func TSNE(embs []v1.Embedding, projDim v1.Dim) ([]v1.Embedding, error) {
 
 // Compute computes p projections (2D and 3D) for embeddings embs and returns them.
 func Compute(embs []v1.Embedding, p v1.Projection) (map[v1.Dim][]v1.Embedding, error) {
+	if len(embs) == 0 {
+		return map[v1.Dim][]v1.Embedding{
+			v1.Dim2D: {},
+			v1.Dim3D: {},
+		}, nil
+	}
 	var (
 		err    error
 		proj2D []v1.Embedding


### PR DESCRIPTION
previoously we tried accessing the first element in the embeddings retrieved from in-memory store even in the cases when there are no embeddings. This caused a panic when recomputing projections for empty embedding store - let's return empty JSON when no embeddings are stored in the in-memory store.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9380ce710410cc7c2da4326a51eb707b64a386f3.  | 
|--------|--------|

### Summary:
This PR modifies the `Compute` function in `/api/v1/internal/projection/projection.go` to return an empty map for 2D and 3D projections when the input embeddings slice is empty, preventing a potential runtime error.

**Key points**:
- Added a condition in `Compute` function in `/api/v1/internal/projection/projection.go` to check if `embs` slice is empty.
- If `embs` is empty, the function now returns an empty map with keys `v1.Dim2D` and `v1.Dim3D`.
- This change prevents a potential runtime error when the function is called with an empty slice.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
