### PR TITLE
update: label data projections

### DIFF
--- a/api/v1/http/embedders.go
+++ b/api/v1/http/embedders.go
@@ -3,9 +3,12 @@ package http
 import (
 	"context"
 	"errors"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	v1 "github.com/milosgajdos/embeviz/api/v1"
+	"github.com/milosgajdos/embeviz/api/v1/internal"
 	"github.com/milosgajdos/go-embeddings"
 	"github.com/milosgajdos/go-embeddings/cohere"
 	"github.com/milosgajdos/go-embeddings/document/text"
@@ -13,18 +16,22 @@ import (
 	"github.com/milosgajdos/go-embeddings/vertexai"
 )
 
+const (
+	MaxLabelSize = 100 // NOTE: chosen arbitrarily
+)
+
 // FetchEmbeddings fetches embeddings using the provided embedder.
 // It returns the fetched embeddings or fails with error.
 func FetchEmbeddings(ctx context.Context, embedder any, req *v1.EmbeddingsUpdate) ([]v1.Embedding, error) {
+	if len(req.Text) == 0 {
+		return []v1.Embedding{}, nil
+	}
+
 	var (
 		vals []float64
 		embs []*embeddings.Embedding
 		err  error
 	)
-
-	if len(req.Text) == 0 {
-		return []v1.Embedding{}, nil
-	}
 
 	chunks := []string{req.Text}
 
@@ -42,9 +49,9 @@ func FetchEmbeddings(ctx context.Context, embedder any, req *v1.EmbeddingsUpdate
 		chunks = rs.Split(req.Text)
 	}
 
-	// TODO: make sure the input vals for Embedding request
-	// isn't exceeding max number of tokens e.g.
-	// for OpenAI: https://platform.openai.com/docs/api-reference/embeddings/create
+	// TODO: make sure the input for Embedding request
+	// isn't exceeding max allowed number of tokens
+	// e.g. for OpenAI: https://platform.openai.com/docs/api-reference/embeddings/create
 
 	results := make([]v1.Embedding, 0, len(chunks))
 
@@ -92,16 +99,42 @@ func FetchEmbeddings(ctx context.Context, embedder any, req *v1.EmbeddingsUpdate
 		return nil, errors.New("unsupported provider")
 	}
 
-	for _, emb := range embs {
+	for i, emb := range embs {
+		// NOTE: each embedding has its own copy of metadata
+		// so we can set the labels per embedding, etc.
+		md := make(map[string]any)
+		for k, v := range req.Metadata {
+			md[k] = v
+		}
+		label := req.Metadata[v1.LabelMetaKey]
+		// NOTE: if the type assertion fail, stringLabel is emoty string
+		stringLabel, _ := label.(string)
+		md[v1.LabelMetaKey] = getLabel(stringLabel, chunks[i])
+
 		vals = make([]float64, len(emb.Vector))
 		copy(vals, emb.Vector)
 		r := v1.Embedding{
 			UID:      uuid.NewString(),
 			Values:   vals,
-			Metadata: req.Metadata,
+			Metadata: md,
 		}
 		results = append(results, r)
 	}
 
 	return results, nil
+}
+
+func getLabel(label, chunk string) string {
+	if len(label) == 0 {
+		label = chunk
+	} else {
+		label = strings.Join([]string{label, chunk}, ": ")
+	}
+
+	size := utf8.RuneCountInString(label)
+	if size > MaxLabelSize {
+		label, _ = internal.SplitStringByChars(chunk, MaxLabelSize)
+	}
+
+	return label
 }

--- a/api/v1/http/providers.go
+++ b/api/v1/http/providers.go
@@ -274,23 +274,20 @@ func (s *Server) UpdateProviderEmbeddings(c *fiber.Ctx) error {
 		})
 	}
 
+	if req.Metadata == nil {
+		req.Metadata = make(map[string]any)
+	}
+	req.Metadata[v1.ProjMetaKey] = req.Projection
+	if req.Label != "" {
+		req.Metadata[v1.LabelMetaKey] = req.Label
+	}
+
 	ctx := context.Background()
 	embs, err := FetchEmbeddings(ctx, embedder, req)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(v1.ErrorResponse{
 			Error: err.Error(),
 		})
-	}
-
-	if req.Metadata == nil {
-		req.Metadata = make(map[string]any)
-	}
-	req.Metadata["projection"] = req.Projection
-	if req.Label != "" {
-		req.Metadata["label"] = req.Label
-	}
-	for _, e := range embs {
-		e.Metadata = req.Metadata
 	}
 
 	res, err := s.ProvidersService.UpdateProviderEmbeddings(ctx, uid.String(), embs, req.Projection)

--- a/api/v1/internal/split.go
+++ b/api/v1/internal/split.go
@@ -1,0 +1,27 @@
+package internal
+
+import "unicode/utf8"
+
+// SplitStringByChars slices the input string into two parts:
+// 1. has exactly size characters
+// 2. contains the remaining characters
+func SplitStringByChars(s string, size int) (string, string) {
+	// If the string is empty or size is 0, return empty strings
+	if s == "" || size == 0 {
+		return "", s
+	}
+	// Initialize variables to track the indices for slicing
+	var i, runeCount int
+	// Iterate over the string
+	for i < len(s) && runeCount < size {
+		// Decode the next rune
+		// NOTE: i is incremented by the byte size of runes so slicing
+		// the string s is safe without breaking multibyte chars
+		_, runeSize := utf8.DecodeRuneInString(s[i:])
+		// Increase rune count and move to the next rune
+		runeCount++
+		i += runeSize
+	}
+	// Return the first part of the string and the remaining part
+	return s[:i], s[i:]
+}

--- a/api/v1/internal/split_test.go
+++ b/api/v1/internal/split_test.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestSplitStringByChars(t *testing.T) {
+	var testCases = []struct {
+		given string
+		size  int
+		exp   []string
+	}{
+		{"", 5, []string{"", ""}},
+		{"こんにちは世界", 5, []string{"こんにちは", "世界"}},
+		{"こんにちは世界", 10, []string{"こんにちは世界", ""}},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("s=%s, size=%d", tc.given, tc.size), func(t *testing.T) {
+			t.Parallel()
+			s1, s2 := SplitStringByChars(tc.given, tc.size)
+			if !reflect.DeepEqual([]string{s1, s2}, tc.exp) {
+				t.Errorf("expected: %s, got: %s", tc.exp, []string{s1, s2})
+			}
+		})
+	}
+}

--- a/api/v1/providers.go
+++ b/api/v1/providers.go
@@ -57,6 +57,11 @@ type ProviderFilter struct {
 	Limit  int `json:"limit"`
 }
 
+const (
+	ProjMetaKey  = "projection"
+	LabelMetaKey = "label"
+)
+
 // EmbeddingsUpdate is used to fetch embeddings.
 // NOTE: we call this an Update because it updates the vector store.
 type EmbeddingsUpdate struct {

--- a/ui/src/components/echart/options.js
+++ b/ui/src/components/echart/options.js
@@ -17,7 +17,7 @@ const defaultToolbox = {
 
 const defaultToolTip = {
   show: true,
-  formatter: "{b} [{c}]",
+  formatter: "{b}",
 };
 
 const defaultLegend = {


### PR DESCRIPTION
We use the actual raw data as labels, limiting the size of the labels to some rather randomly selected value. We truncate the input string to the number of max characters.

If the label is provided in the POST request we prepend it to the final label and truncate to the max char.

We also no longer expose the embeddings vals via labels in the UI.