### PR TITLE
update: remove sort-by package

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,8 +15,7 @@
         "match-sorter": "^6.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.0",
-        "sort-by": "^1.2.0"
+        "react-router-dom": "^6.21.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -5716,14 +5715,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/object-path": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz",
-      "integrity": "sha512-fxrwsCFi3/p+LeLOAwo/wyRMODZxdGBtUlWRzsEpsUVrisZbEfZ21arxLGfaWfcnqb8oHPNihIb4XPE8CQPN5A==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/object.assign": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
@@ -6759,14 +6750,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
       "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw=="
-    },
-    "node_modules/sort-by": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-1.2.0.tgz",
-      "integrity": "sha512-aRyW65r3xMnf4nxJRluCg0H/woJpksU1dQxRtXYzau30sNBOmf5HACpDd9MZDhKh7ALQ5FgSOfMPwZEtUmMqcg==",
-      "dependencies": {
-        "object-path": "0.6.0"
-      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,8 +17,7 @@
     "match-sorter": "^6.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.0",
-    "sort-by": "^1.2.0"
+    "react-router-dom": "^6.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",

--- a/ui/src/lib/embeddings.js
+++ b/ui/src/lib/embeddings.js
@@ -1,5 +1,4 @@
 import { matchSorter } from "match-sorter";
-import sortBy from "sort-by";
 
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:5050/api/v1";
 
@@ -20,10 +19,10 @@ export async function getProviders(query) {
     let providers = respData.providers;
     if (!providers) return [];
 
-    if (query) {
-      providers = matchSorter(providers, query, { keys: ["name"] });
+    if (!query) {
+      query = "";
     }
-    return providers.sort(sortBy("name"));
+    return matchSorter(providers, query, { keys: ["name"] });
   } catch (error) {
     console.error("An error occurred:", error.message);
     throw new Error(`Error fetching providers! Message: ${error.message}`);


### PR DESCRIPTION
[sort-by](https://www.npmjs.com/package/sort-by) depends on a vulnerable dependency and is redundant in general. We can handle what it does by [match-sorter](https://www.npmjs.com/package/match-sorter).