### PR TITLE
Bump Go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         go:
-          - '1.20'
-          - '1.21'
+          - '1.22'
+          - '1.23'
 
     steps:
 
@@ -91,8 +91,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         go:
-          - '1.20'
-          - '1.21'
+          - '1.22'
+          - '1.23'
 
     steps:
 
@@ -135,4 +135,4 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.56
+        version: v1.63

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
     - gofmt
     - revive
     - ineffassign
-    - vet
     - unused
     - misspell
     - bodyclose
@@ -15,6 +14,8 @@ linters:
 
 run:
   deadline: 2m
+
+issues:
   skip-dirs:
     - vendor
     - ui

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/milosgajdos/embeviz
 
-go 1.21
+go 1.22
 
 require (
 	github.com/danaugrs/go-tsne/tsne v0.0.0-20220306155740-2250969e057f


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump Go version to `1.22` and update CI workflows and linter configuration.
> 
>   - **Go Version Update**:
>     - Bump Go version from `1.21` to `1.22` in `go.mod`.
>     - Update Go versions in `.github/workflows/ci.yaml` from `1.20` and `1.21` to `1.22` and `1.23`.
>   - **Linter Configuration**:
>     - Remove `vet` linter from `.golangci.yml`.
>     - Update `golangci-lint` version to `v1.63` in `.github/workflows/ci.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=milosgajdos%2Fembeviz&utm_source=github&utm_medium=referral)<sup> for d6faad218409030e585e022b84c62d67e3cce7a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->